### PR TITLE
Provide custom authentication handler

### DIFF
--- a/arsa/arsa.py
+++ b/arsa/arsa.py
@@ -90,7 +90,7 @@ class Arsa(object):
         policy = Policy(auth_event['authorizationToken'], auth_event['methodArn'], allow=True, context=context)
 
         if self.authorizer_func:
-            policy = self.authorizer_func(auth_event)
+            policy = self.authorizer_func(auth_event, context)
 
         return policy.as_dict()
 

--- a/arsa/arsa.py
+++ b/arsa/arsa.py
@@ -87,7 +87,7 @@ class Arsa(object):
         }
 
     def authorize(self, auth_event, context):
-        policy = Policy(auth_event['authorizationToken'], auth_event['methodArn'], allow=True)
+        policy = Policy(auth_event)
 
         if self.authorizer_func:
             policy = self.authorizer_func(auth_event, context)

--- a/arsa/arsa.py
+++ b/arsa/arsa.py
@@ -2,12 +2,13 @@
 import json
 from werkzeug.routing import Map
 from werkzeug.wrappers import Request, Response
-from werkzeug.exceptions import HTTPException, Unauthorized, BadRequest
-from werkzeug.test import EnvironBuilder, run_wsgi_app
+from werkzeug.exceptions import HTTPException, BadRequest
+from werkzeug.test import run_wsgi_app
 
 from .routes import RouteFactory
 from .util import to_serializable
 from .policy import Policy
+from .wrappers import AWSEnvironBuilder
 
 class Arsa(object):
     """
@@ -21,14 +22,14 @@ class Arsa(object):
 
         self.authorizer_func = None
 
-    def route(self, rule, methods=None):
+    def route(self, rule, methods=None, inject_request=False):
         """ Convenience decorator for defining a route """
         if methods is None:
             methods = ['GET']
 
         def decorator(func):
             route = self.factory.register_endpoint(func)
-            route.set_rule(rule, methods)
+            route.set_rule(rule, methods, inject_request=inject_request)
             return func
 
         return decorator
@@ -59,22 +60,9 @@ class Arsa(object):
         return decorator
 
     def handler(self, event, context):
-        app = self.create_app(check_token=False)
+        app = self.create_app()
 
-        query_string = None
-        if 'queryStringParameters' in event:
-            if isinstance(event['queryStringParameters'], dict):
-                query_string = '?'.join(
-                    ['{}={}'.format(k, v) for k, v in event['queryStringParameters'].items()]
-                )
-
-        builder = EnvironBuilder(
-            path=event['path'],
-            method=event['httpMethod'],
-            headers=event['headers'],
-            data=event['body'],
-            query_string=query_string
-        )
+        builder = AWSEnvironBuilder(event, context)
         builder.close()
         resp = run_wsgi_app(app, builder.get_environ())
 
@@ -94,7 +82,7 @@ class Arsa(object):
 
         return policy.as_dict()
 
-    def create_app(self, check_token=True):
+    def create_app(self):
 
         if not self.routes:
             self.routes = Map(rules=[self.factory]).bind('arsa.io')
@@ -106,9 +94,6 @@ class Arsa(object):
                 # Find url rule
                 (rule, arguments) = self.routes.match(req.path, method=req.method, return_rule=True)
 
-                if check_token and rule.token_required and 'x-api-token' not in req.headers:
-                    raise Unauthorized("Not token sent.")
-
                 if req.data:
                     try:
                         data = json.loads(req.data)
@@ -116,11 +101,11 @@ class Arsa(object):
                     except ValueError:
                         raise BadRequest("JSON body was malformed")
 
-                if req.args:
-                    arguments.update({'query': dict(req.args)})
-
                 rule.has_valid_arguments(arguments)
                 decoded_args = rule.decode_arguments(arguments)
+
+                if rule.inject_request:
+                    decoded_args['_req'] = req
 
                 body = rule.endpoint(**decoded_args)
 

--- a/arsa/arsa.py
+++ b/arsa/arsa.py
@@ -86,8 +86,8 @@ class Arsa(object):
             "body": response.get_data(as_text=True)
         }
 
-    def authorize(self, auth_event):
-        policy = Policy(auth_event['authorizationToken'], auth_event['methodArn'], allow=True)
+    def authorize(self, auth_event, context):
+        policy = Policy(auth_event['authorizationToken'], auth_event['methodArn'], allow=True, context=context)
 
         if self.authorizer_func:
             policy = self.authorizer_func(auth_event)

--- a/arsa/arsa.py
+++ b/arsa/arsa.py
@@ -87,7 +87,7 @@ class Arsa(object):
         }
 
     def authorize(self, auth_event, context):
-        policy = Policy(auth_event['authorizationToken'], auth_event['methodArn'], allow=True, context=context)
+        policy = Policy(auth_event['authorizationToken'], auth_event['methodArn'], allow=True)
 
         if self.authorizer_func:
             policy = self.authorizer_func(auth_event, context)

--- a/arsa/cli.py
+++ b/arsa/cli.py
@@ -89,8 +89,8 @@ class DeployCommand(object):
         if self.session.get_credentials() is None:
             raise click.ClickException('No Arsa or AWS credentials were found.')
 
+        # Infrastructure Id's
         self.account_id = self.session.client('sts').get_caller_identity().get('Account')
-
         self.rest_api_id = None
         self.role_arn = None
         self.authorizer_id = None
@@ -115,7 +115,7 @@ class DeployCommand(object):
         if 'authorization' in self.config:
             auth_name = '{}-auth'.format(api_name)
             auth_handler = self.config['authorization']['handler']
-            self._create_lambda('{}:{}-auth'.format(self.account_id, auth_name), auth_handler, buf)
+            self._create_lambda('{}:{}'.format(self.account_id, auth_name), auth_handler, buf)
 
             click.secho('Setting up auth...', fg='green')
             self._setup_api_auth(auth_name)
@@ -323,7 +323,7 @@ class DeployCommand(object):
             resource_id = resp['id']
 
             # Setup ANY method
-            if self.authorizer_id:
+            if not self.authorizer_id:
                 api_client.put_method(
                     restApiId=self.rest_api_id,
                     resourceId=resource_id,

--- a/arsa/policy.py
+++ b/arsa/policy.py
@@ -1,10 +1,18 @@
 class Policy(object):
 
-    def __init__(self, principal_id, arn, allow=True, context=None):
-        self.principal_id = principal_id
-        self.arn = arn
+    def __init__(self, event, allow=True, context=None):
+        self.token = event['authorizationToken']
+        self.arn = Policy.__get_resource_arn(event['methodArn'])
+
+        # Set default principal_id to token
+        self.principal_id = self.token
         self.allow = allow
         self.context = context
+
+    @staticmethod
+    def __get_resource_arn(arn):
+        second_idx = arn.rfind('/', 0, arn.rfind('/'))
+        return arn[:second_idx] + '/*/*'
 
     def as_dict(self):
         return {

--- a/arsa/policy.py
+++ b/arsa/policy.py
@@ -1,0 +1,22 @@
+class Policy(object):
+
+    def __init__(self, principal_id, arn, allow=True, context=None):
+        self.principal_id = principal_id
+        self.arn = arn
+        self.allow = allow
+        self.context = context
+
+    def as_dict(self):
+        return {
+            'principalId': self.principal_id,
+            'policyDocument': {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Action": "execute-api:Invoke",
+                        "Effect": ('Allow' if self.allow else 'Deny'),
+                        "Resource": self.arn
+                    }
+                ]},
+            'context': self.context
+        }

--- a/arsa/routes.py
+++ b/arsa/routes.py
@@ -12,6 +12,7 @@ class Route(Rule):
         super(Route, self).__init__('/_arsa', endpoint=endpoint, **kwargs)
         self._conditions = {}
         self._token_required = False
+        self.inject_request = False
 
     @property
     def token_required(self):
@@ -21,9 +22,9 @@ class Route(Rule):
     def token_required(self, value):
         self._token_required = value
 
-    def set_rule(self, rule, methods=None):
+    def set_rule(self, rule, methods=None, inject_request=False):
         self.rule = rule
-
+        self.inject_request = inject_request
         # Taken from super class init method
         if methods is None:
             self.methods = None

--- a/arsa/wrappers.py
+++ b/arsa/wrappers.py
@@ -18,10 +18,11 @@ class AWSEnvironBuilder(EnvironBuilder):
             query_string=query_string
         )
 
-        self.context = context
+
+        self.requestContext = event.get('requestContext', None)
 
 
     def get_environ(self):
         environ = super(AWSEnvironBuilder, self).get_environ()
-        environ['aws.context'] = self.context
+        environ['aws.requestContext'] = self.requestContext
         return environ

--- a/arsa/wrappers.py
+++ b/arsa/wrappers.py
@@ -1,5 +1,4 @@
 from werkzeug.test import EnvironBuilder
-from werkzeug.wrappers import Request
 
 class AWSEnvironBuilder(EnvironBuilder):
 
@@ -20,3 +19,9 @@ class AWSEnvironBuilder(EnvironBuilder):
         )
 
         self.context = context
+
+
+    def get_environ(self):
+        environ = super(AWSEnvironBuilder, self).get_environ()
+        environ['aws.context'] = self.context
+        return environ

--- a/arsa/wrappers.py
+++ b/arsa/wrappers.py
@@ -1,0 +1,22 @@
+from werkzeug.test import EnvironBuilder
+from werkzeug.wrappers import Request
+
+class AWSEnvironBuilder(EnvironBuilder):
+
+    def __init__(self, event, context):
+        query_string = None
+        if 'queryStringParameters' in event:
+            if isinstance(event['queryStringParameters'], dict):
+                query_string = '?'.join(
+                    ['{}={}'.format(k, v) for k, v in event['queryStringParameters'].items()]
+                )
+
+        super(AWSEnvironBuilder, self).__init__(
+            path=event['path'],
+            method=event['httpMethod'],
+            headers=event['headers'],
+            data=event['body'],
+            query_string=query_string
+        )
+
+        self.context = context

--- a/arsa/wrappers.py
+++ b/arsa/wrappers.py
@@ -19,10 +19,11 @@ class AWSEnvironBuilder(EnvironBuilder):
         )
 
 
-        self.requestContext = event.get('requestContext', None)
-
+        self.request_context = event.get('requestContext', None)
+        self.lambda_context = context
 
     def get_environ(self):
         environ = super(AWSEnvironBuilder, self).get_environ()
-        environ['aws.requestContext'] = self.requestContext
+        environ['aws.requestContext'] = self.request_context
+        environ['aws.lambdaContext'] = self.lambda_context
         return environ

--- a/example-app/arsa.json
+++ b/example-app/arsa.json
@@ -1,4 +1,11 @@
 {
   "name": "example-app",
-  "handler": "users.handler"
+  "handler": "users.handler",
+  "authorization": {
+    "handler": "users.authorize",
+    "type": "lambda",
+    "token_source": "x-api-token",
+    "token_validation": ".*",
+    "ttl": 300
+  }
 }

--- a/example-app/arsa.json
+++ b/example-app/arsa.json
@@ -3,9 +3,8 @@
   "handler": "users.handler",
   "authorization": {
     "handler": "users.authorize",
-    "type": "lambda",
     "token_source": "method.request.header.x-arsa-token",
     "token_validation": ".*",
-    "ttl": 300
+    "ttl": 30
   }
 }

--- a/example-app/arsa.json
+++ b/example-app/arsa.json
@@ -4,7 +4,7 @@
   "authorization": {
     "handler": "users.authorize",
     "type": "lambda",
-    "token_source": "x-api-token",
+    "token_source": "method.request.header.x-arsa-token",
     "token_validation": ".*",
     "ttl": 300
   }

--- a/example-app/requirements.txt
+++ b/example-app/requirements.txt
@@ -1,1 +1,1 @@
-git+git://github.com/trippingrobot/arsa-sdk-python@auth
+git+git://github.com/trippingrobot/arsa-sdk-python@dev

--- a/example-app/requirements.txt
+++ b/example-app/requirements.txt
@@ -1,1 +1,1 @@
-git+git://github.com/trippingrobot/arsa-sdk-python@dev
+git+git://github.com/trippingrobot/arsa-sdk-python@auth

--- a/example-app/users.py
+++ b/example-app/users.py
@@ -21,10 +21,11 @@ def create_user(name, **optional_kwargs):
     email = optional_kwargs['email'] if 'email' in optional_kwargs else None
     return {'id':'124', 'name':name, 'email':email}
 
-@app.route("/account")
+@app.route("/account", inject_request=True)
 def get_account(_req):
     """ Get account with params """
-    principal_id = _req.environ['aws.context']['authorizer']['principalId']
+    print(_req.environ['aws.requestContext'])
+    principal_id = _req.environ['aws.requestContext'].authorizer.principalId
     return {'id':principal_id, 'name':'Acme Inc.', 'email':'support@acme.io'}
 
 @app.route("/accounts", methods=['POST'])

--- a/example-app/users.py
+++ b/example-app/users.py
@@ -36,10 +36,18 @@ def create_account(name, owner, **optional_kwargs):
 
 @app.authorizer()
 def custom_auth(auth_event, context):
-    # TODO: Check for authorization
-    principal_id = auth_event['authorizationToken']
-    arn = auth_event['methodArn']
-    return Policy(principal_id, arn, allow=True)
+    # Create base policy from auth event
+    policy = Policy(auth_event)
+
+    # Set permission
+    policy.allow = (policy.token == 'test_token')
+
+    # Pass value to backend
+    policy.principal_id = 'user'
+
+    print(policy.as_dict())
+
+    return policy
 
 
 handler = app.handler

--- a/example-app/users.py
+++ b/example-app/users.py
@@ -34,12 +34,12 @@ def create_account(name, owner, **optional_kwargs):
     return {'id':'124', 'name':name, 'owner': owner, 'partner': optional_kwargs.get('partner', None)}
 
 
-@app.authorizer
-def custom_auth(auth_event):
+@app.authorizer()
+def custom_auth(auth_event, context):
     # TODO: Check for authorization
     principal_id = auth_event['authorizationToken']
     arn = auth_event['methodArn']
-    return Policy(principal_id, arn, allow=True) # OR DenyPolicy(principal_id, context)
+    return Policy(principal_id, arn, allow=True, context=context)
 
 
 handler = app.handler

--- a/example-app/users.py
+++ b/example-app/users.py
@@ -24,7 +24,7 @@ def create_user(name, **optional_kwargs):
 @app.route("/account")
 def get_account(_req):
     """ Get account with params """
-    principal_id = _req.environ.context['authorizer']['principalId']
+    principal_id = _req.environ['aws.context']['authorizer']['principalId']
     return {'id':principal_id, 'name':'Acme Inc.', 'email':'support@acme.io'}
 
 @app.route("/accounts", methods=['POST'])

--- a/example-app/users.py
+++ b/example-app/users.py
@@ -17,14 +17,15 @@ def list_users():
 @app.required(name=str)
 @app.optional(email=str)
 def create_user(name, **optional_kwargs):
-    """ Create user if client is authenticated """
+    """ Create user """
     email = optional_kwargs['email'] if 'email' in optional_kwargs else None
     return {'id':'124', 'name':name, 'email':email}
 
-@app.route("/accounts/<account_id>")
-def get_account(account_id):
+@app.route("/account")
+def get_account(_req):
     """ Get account with params """
-    return [{'id':account_id, 'name':'Acme Inc.', 'email':'support@acme.io'}]
+    principal_id = _req.environ.context['authorizer']['principalId']
+    return {'id':principal_id, 'name':'Acme Inc.', 'email':'support@acme.io'}
 
 @app.route("/accounts", methods=['POST'])
 @app.required(name=str, owner=Person)
@@ -44,8 +45,6 @@ def custom_auth(auth_event, context):
 
     # Pass value to backend
     policy.principal_id = 'user'
-
-    print(policy.as_dict())
 
     return policy
 

--- a/example-app/users.py
+++ b/example-app/users.py
@@ -1,5 +1,6 @@
 from arsa import Arsa
 from arsa.model import Model, Attribute
+from arsa.policy import Policy
 
 class Person(Model):
     name = Attribute(str)
@@ -26,7 +27,6 @@ def get_account(account_id):
     return [{'id':account_id, 'name':'Acme Inc.', 'email':'support@acme.io'}]
 
 @app.route("/accounts", methods=['POST'])
-@app.token_required()
 @app.required(name=str, owner=Person)
 @app.optional(partner=Person)
 def create_account(name, owner, **optional_kwargs):
@@ -34,4 +34,13 @@ def create_account(name, owner, **optional_kwargs):
     return {'id':'124', 'name':name, 'owner': owner, 'partner': optional_kwargs.get('partner', None)}
 
 
+@app.authorizer
+def custom_auth(auth_event):
+    # TODO: Check for authorization
+    principal_id = auth_event['authorizationToken']
+    arn = auth_event['methodArn']
+    return Policy(principal_id, arn, allow=True) # OR DenyPolicy(principal_id, context)
+
+
 handler = app.handler
+authorize = app.authorize

--- a/example-app/users.py
+++ b/example-app/users.py
@@ -24,8 +24,7 @@ def create_user(name, **optional_kwargs):
 @app.route("/account", inject_request=True)
 def get_account(_req):
     """ Get account with params """
-    print(_req.environ['aws.requestContext'])
-    principal_id = _req.environ['aws.requestContext'].authorizer.principalId
+    principal_id = _req.environ['aws.requestContext']['authorizer']['principalId']
     return {'id':principal_id, 'name':'Acme Inc.', 'email':'support@acme.io'}
 
 @app.route("/accounts", methods=['POST'])

--- a/example-app/users.py
+++ b/example-app/users.py
@@ -39,7 +39,7 @@ def custom_auth(auth_event, context):
     # TODO: Check for authorization
     principal_id = auth_event['authorizationToken']
     arn = auth_event['methodArn']
-    return Policy(principal_id, arn, allow=True, context=context)
+    return Policy(principal_id, arn, allow=True)
 
 
 handler = app.handler

--- a/test/test_arsa.py
+++ b/test/test_arsa.py
@@ -167,10 +167,10 @@ def test_error_handler(app):
     assert response['statusCode'] == 400
 
 def test_get_route_with_query_params(app):
-    func = MagicMock(testfunc, side_effect=lambda **kwargs: kwargs['query']['happy'])
-    app.route('/foobar')(func)
+    func = MagicMock(testfunc, side_effect=lambda **kwargs: kwargs['_req'].args['happy'])
+    app.route('/foobar', inject_request=True)(func)
 
     client = Client(app.create_app(), response_wrapper=Response)
     response = client.get('/foobar?bob=star&happy=lucky')
     assert response.status_code == 200
-    assert response.data == b'["lucky"]'
+    assert response.data == b'"lucky"'

--- a/test/test_arsa.py
+++ b/test/test_arsa.py
@@ -103,17 +103,32 @@ def test_optional_invalid_route_value(app):
     assert response.status_code == 400
 
 def test_auth(app):
-    res = app.authorize({'type':'TOKEN', 'authorizationToken':'sampletoken', 'methodArn':'arn://'})
+    auth_event = {
+        'type': 'TOKEN',
+        'authorizationToken' : 'test1234',
+        'methodArn': 'arn:aws:execute-api:us-west-2:123456789012:ymy8tbxw7b/v1/GET/{proxy+}'
+    }
+
+    res = app.authorize(auth_event, {})
     assert res['policyDocument']['Statement'][0]['Effect'] == 'Allow'
 
 def test_custom_auth(app):
-    deny = Policy('user', 'arn', allow=False, context={'custom_attr':'string'})
+    auth_event = {
+        'type': 'TOKEN',
+        'authorizationToken' : 'test1234',
+        'methodArn': 'arn:aws:execute-api:us-west-2:123456789012:ymy8tbxw7b/v1/GET/{proxy+}'
+    }
+
+    deny = Policy(auth_event, allow=False, context={'custom_attr':'string'})
+    deny.principal_id = 'user'
     func = MagicMock(testfunc, return_value=deny)
+
     app.authorizer()(func)
-    res = app.authorize({'type':'TOKEN', 'authorizationToken':'sampletoken', 'methodArn':'arn://'})
+    res = app.authorize(auth_event, {})
     assert res['policyDocument']['Statement'][0]['Effect'] == 'Deny'
     assert res['principalId'] == 'user'
     assert res['context']['custom_attr'] == 'string'
+    assert res['policyDocument']['Statement'][0]['Resource'] == 'arn:aws:execute-api:us-west-2:123456789012:ymy8tbxw7b/v1/*/*'
 
 def test_validate_route_with_model(app):
     func = MagicMock(testfunc, side_effect=lambda tester: tester.name)


### PR DESCRIPTION
## Auth

- Arsa now allows you to provide a custom authorizer to create your own policy.
- By default, Arsa will not deploy with authentication. If you define an `authorization` configuration in `arsa.json` then it will create an authorizer when creating the resource for the API.

```
@app.authorizer()
def custom_auth(auth_event, context):
    # Create base policy from auth event
    policy = Policy(auth_event)

    # Set permission
    policy.allow = (policy.token == 'test_token')

    # Pass value to backend
    policy.principal_id = 'user'

    return policy

```